### PR TITLE
Inject dataslayerLaunchMonitors in <head>, not as a direct descendant of <html>

### DIFF
--- a/public/injectlaunchmonitors.js
+++ b/public/injectlaunchmonitors.js
@@ -111,6 +111,6 @@ if (!document.querySelector('#dataslayerLaunchMonitors')) {
     dsLaunchMonitors.id = 'dataslayerLaunchMonitors';
     //dsLaunchMonitors.type = 'text/javascript';
     dsLaunchMonitors.textContent = launchMonitorScript;
-    document.documentElement.appendChild(dsLaunchMonitors);
+    document.head.appendChild(dsLaunchMonitors);
   }
 }


### PR DESCRIPTION
Currently, dataSlayer incorrectly injects `dataslayerLaunchMonitors` script as a direct children of `<html>`.
As a result, it makes many third party scripts (like Google Analytics) insert themselves in `<html>`, and not in `<head>`.